### PR TITLE
Fix/#7 docker production image changes

### DIFF
--- a/docker/Dockerfile-Redhat
+++ b/docker/Dockerfile-Redhat
@@ -2,30 +2,30 @@ FROM registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift
 
 USER root
 
-ENV APP_DIR=app \
-    GROUP_NAME=networknt \
+ENV GROUP_NAME=networknt \
     GROUP_ID=1000 \
     USER_NAME=networknt \
     USER_UID=1000
 
 RUN groupadd -g ${GROUP_ID} -r ${GROUP_NAME} && \
-    useradd -u ${USER_UID} -g ${GROUP_NAME} -d "/${APP_DIR}" -s /sbin/nologin -c "${USER_NAME} user" ${USER_NAME}
+    useradd --no-log-init -u ${USER_UID} -r -g ${GROUP_NAME} ${USER_NAME}
 
-# Add the jar file into the container at /app
-ADD target/light-proxy.jar ./${APP_DIR}/server.jar
+# Add the jar file
+ADD target/light-proxy.jar server.jar
 
-# change permissions of app directory
-RUN mkdir -p ./${APP_DIR}/config && \
-    chown -R ${USER_NAME}:0 "./${APP_DIR}/config" && \
-    find "./${APP_DIR}/config" -type d -exec chmod 750 {} \; && \
-    find "./${APP_DIR}/config" -type f -exec chmod 640 {} \;
+RUN ls -al ./
+  
+# change permissions of the directory
+RUN mkdir -p /config && \
+    chown -R ${USER_NAME}:0 "/config" && \
+    find "/config" -type d -exec chmod 750 {} \; && \
+    find "/config" -type f -exec chmod 640 {} \; && \
+
+RUN ls -al / && ls -al /config && ls -al ./
 
 # Port available to the world outside of this container
 EXPOSE 8080
 
 USER ${USER_UID}
-
-# Set the working directory to /app
-WORKDIR ./${APP_DIR}
 
 CMD ["/bin/sh","-c","java -Dlight-4j-config-dir=/config -Dlogback.configurationFile=/config/logback.xml -jar server.jar"]

--- a/docker/Dockerfile-Redhat
+++ b/docker/Dockerfile-Redhat
@@ -1,31 +1,11 @@
 FROM registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift
 
-USER root
-
-ENV GROUP_NAME=networknt \
-    GROUP_ID=1000 \
-    USER_NAME=networknt \
-    USER_UID=1000
-
-RUN groupadd -g ${GROUP_ID} -r ${GROUP_NAME} && \
-    useradd --no-log-init -u ${USER_UID} -r -g ${GROUP_NAME} ${USER_NAME}
-
 # Add the jar file
 ADD target/light-proxy.jar server.jar
-
-RUN ls -al ./
-  
-# change permissions of the directory
-RUN mkdir -p /config && \
-    chown -R ${USER_NAME}:0 "/config" && \
-    find "/config" -type d -exec chmod 750 {} \; && \
-    find "/config" -type f -exec chmod 640 {} \; && \
-
-RUN ls -al / && ls -al /config && ls -al ./
 
 # Port available to the world outside of this container
 EXPOSE 8080
 
-USER ${USER_UID}
+USER 1001
 
 CMD ["/bin/sh","-c","java -Dlight-4j-config-dir=/config -Dlogback.configurationFile=/config/logback.xml -jar server.jar"]

--- a/docker/Dockerfile-Redhat
+++ b/docker/Dockerfile-Redhat
@@ -6,6 +6,4 @@ ADD target/light-proxy.jar server.jar
 # Port available to the world outside of this container
 EXPOSE 8080
 
-USER 1001
-
 CMD ["/bin/sh","-c","java -Dlight-4j-config-dir=/config -Dlogback.configurationFile=/config/logback.xml -jar server.jar"]


### PR DESCRIPTION
Openshift base image run as a non-root user - https://access.redhat.com/containers/?tab=docker-file#/registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift/images/1.2-6

So removed creation of group/user and steps to change user permissions.

